### PR TITLE
Allow silent notifs to update badge count

### DIFF
--- a/android/src/ti/goosh/IntentService.java
+++ b/android/src/ti/goosh/IntentService.java
@@ -106,6 +106,10 @@ public class IntentService extends GcmListenerService {
 		} else {
 			Log.i(LCAT, "Not showing notification cause missing data.alert");
 			showNotification = false;
+			if (data.has("badge")) {
+				int badge = data.getAsJsonPrimitive("badge").getAsInt();
+				BadgeUtils.setBadge(context, badge);
+			}
 		}
 
 		if (showNotification) {


### PR DESCRIPTION
Thanks for building this awesome module! I added this little piece of code to make it so the badge count could be updated without showing a notification (like a silent notification on iOS).