### PR TITLE
Fixes crashes like #35 #28

### DIFF
--- a/android/src/ti/goosh/IntentService.java
+++ b/android/src/ti/goosh/IntentService.java
@@ -119,7 +119,7 @@ public class IntentService extends GcmListenerService {
 
 			// Parse additional silent features
 
-			if (data.has("badge")) {
+			if (data != null && data.has("badge")) {
 				int badge = data.getAsJsonPrimitive("badge").getAsInt();
 				BadgeUtils.setBadge(context, badge);
 			}


### PR DESCRIPTION
Fixes a crash that happens when you don't send a `data` object.

Stack trace: 

```
[INFO]  I/ti.goosh.IntentService: Not showing notification cause missing data.alert
[ERROR] AndroidRuntime: FATAL EXCEPTION: AsyncTask #5
[ERROR] AndroidRuntime: Process: com.app.demo, PID: 32621
[ERROR] AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean com.google.gson.JsonObject.has(java.lang.String)' on a null object reference
[ERROR] AndroidRuntime:     at ti.goosh.IntentService.parseNotification(IntentService.java:122)
[ERROR] AndroidRuntime:     at ti.goosh.IntentService.onMessageReceived(IntentService.java:54)
[ERROR] AndroidRuntime:     at com.google.android.gms.gcm.GcmListenerService.zzq(Unknown Source)
[ERROR] AndroidRuntime:     at com.google.android.gms.gcm.GcmListenerService.zzp(Unknown Source)
[ERROR] AndroidRuntime:     at com.google.android.gms.gcm.GcmListenerService.zzo(Unknown Source)
[ERROR] AndroidRuntime:     at com.google.android.gms.gcm.GcmListenerService.zza(Unknown Source)
[ERROR] AndroidRuntime:     at com.google.android.gms.gcm.GcmListenerService$1.run(Unknown Source)
[ERROR] AndroidRuntime:     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
[ERROR] AndroidRuntime:     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
[ERROR] AndroidRuntime:     at java.lang.Thread.run(Thread.java:818)
```