### PR TITLE
Fixed notifications not displayed when the app is in background state

### DIFF
--- a/android/src/ti/goosh/BroadcastReceiver.java
+++ b/android/src/ti/goosh/BroadcastReceiver.java
@@ -13,10 +13,10 @@ import android.util.Log;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Build;
 import android.os.SystemClock;
 import android.util.Log;
 import android.app.Activity;
-import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.titanium.util.TiRHelper;
 
 import com.google.android.gms.gcm.GcmListenerService;
@@ -29,7 +29,15 @@ public class BroadcastReceiver extends GcmReceiver {
     public void onReceive(Context context, Intent intent) {
         ComponentName comp = new ComponentName(context.getPackageName(),
                 IntentService.class.getName());
-        startWakefulService(context, (intent.setComponent(comp)));
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Bundle extras = intent.getExtras();
+            if (extras != null) {
+                GcmJobService.scheduleJob(context, extras);
+            }
+        } else {
+            startWakefulService(context, (intent.setComponent(comp)));
+        }
         setResultCode(Activity.RESULT_OK);
 
         Log.d(LCAT, "started");

--- a/android/src/ti/goosh/GcmJobService.java
+++ b/android/src/ti/goosh/GcmJobService.java
@@ -1,0 +1,87 @@
+package ti.goosh;
+
+import android.annotation.SuppressLint;
+import android.app.job.JobInfo;
+import android.app.job.JobParameters;
+import android.app.job.JobScheduler;
+import android.app.job.JobService;
+import android.content.ComponentName;
+import android.content.Context;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.support.annotation.RequiresApi;
+
+import java.lang.ref.WeakReference;
+
+@RequiresApi(api = Build.VERSION_CODES.O)
+public class GcmJobService extends JobService {
+
+	private static String LCAT = "ti.goosh.GcmJobService";
+	private static final int JOB_ID = Integer.MAX_VALUE - 4321;
+
+	private GcmAsyncTask mAsyncTask;
+
+	@RequiresApi(api = Build.VERSION_CODES.O)
+	static void scheduleJob(Context context, Bundle extras) {
+		ComponentName jobComponentName = new ComponentName(context.getPackageName(), GcmJobService.class.getName());
+		JobScheduler mJobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+		JobInfo existingInfo = mJobScheduler.getPendingJob(JOB_ID);
+		if (existingInfo != null) {
+			mJobScheduler.cancel(JOB_ID);
+		}
+
+		JobInfo.Builder jobBuilder = new JobInfo.Builder(JOB_ID, jobComponentName)
+				.setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY).setTransientExtras(extras);
+		int result = mJobScheduler.schedule(jobBuilder.build());
+		if (result != JobScheduler.RESULT_SUCCESS) {
+			Log.e(LCAT, "Could not start job, error code: " + result);
+		}
+	}
+
+	@Override
+	public boolean onStartJob(JobParameters params) {
+		mAsyncTask = new GcmAsyncTask(getApplicationContext());
+		mAsyncTask.execute(params);
+		return true;
+	}
+
+	@Override
+	public boolean onStopJob(JobParameters params) {
+		if (mAsyncTask != null) {
+			mAsyncTask.cancel(true);
+			mAsyncTask = null;
+		}
+		return false;
+	}
+
+	private class GcmAsyncTask extends AsyncTask<JobParameters, Void, Void> {
+		private JobParameters params;
+		private WeakReference<Context> contextRef;
+
+		public GcmAsyncTask(Context context) {
+			contextRef = new WeakReference<>(context);
+		}
+
+		@Override
+		protected Void doInBackground(JobParameters... params) {
+			this.params = params[0];
+
+			Bundle extras = this.params.getTransientExtras();
+			try {
+				new IntentService().handleMessage(contextRef.get(), extras);
+			} catch (Exception ex) {
+				Log.e(LCAT, "Exception while handling message: " + ex.getMessage());
+			}
+
+			return null;
+		}
+
+		@Override
+		protected void onPostExecute(Void aVoid) {
+			super.onPostExecute(aVoid);
+			jobFinished(params, false);
+		}
+	};
+}

--- a/android/src/ti/goosh/IntentService.java
+++ b/android/src/ti/goosh/IntentService.java
@@ -61,6 +61,16 @@ public class IntentService extends GcmListenerService {
 		parseNotification(bundle);
 	}
 
+	public void handleMessage(Context context, Bundle bundle) {
+		Log.d(LCAT, "Push notification received");
+		for (String key : bundle.keySet()) {
+			Object value = bundle.get(key);
+			Log.d(LCAT, String.format("Notification key : %s => %s (%s)", key, value.toString(), value.getClass().getName()));
+		}
+
+		parseNotification(context, bundle);
+	}
+
 	private int getResource(String type, String name) {
 		int icon = 0;
 		if (name != null) {
@@ -85,8 +95,8 @@ public class IntentService extends GcmListenerService {
 	}
 
 	@TargetApi(26)
-	private NotificationChannel createOrUpdateDefaultNotificationChannel() {
-		NotificationManager notificationManager = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
+	private NotificationChannel createOrUpdateDefaultNotificationChannel(Context context) {
+		NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 		String channelName = TiApplication.getInstance().getAppProperties().getString("ti.goosh.defaultChannel", DEFAULT_CHANNEL_NAME);
 		NotificationChannel channel = new NotificationChannel(DEFAULT_CHANNEL_ID, channelName, NotificationManager.IMPORTANCE_DEFAULT);
 		notificationManager.createNotificationChannel(channel);
@@ -94,9 +104,12 @@ public class IntentService extends GcmListenerService {
 	}
 
 	private void parseNotification(Bundle bundle) {
+		parseNotification(getApplicationContext(), bundle);
+	}
+
+	private void parseNotification(Context context, Bundle bundle) {
 		TiGooshModule module = TiGooshModule.getModule();
 
-		Context context = getApplicationContext();
 		Boolean appInBackground = !TiApplication.isCurrentActivityInForeground();
 
 		// Flag that determine if the message should be broadcasted to TiGooshModule and call the callback
@@ -169,17 +182,17 @@ public class IntentService extends GcmListenerService {
 		if (showNotification) {
 			Log.w(LCAT, "Show Notification: TRUE");
 
-			Intent notificationIntent = new Intent(this, PushHandlerActivity.class);
+			Intent notificationIntent = new Intent(context, PushHandlerActivity.class);
 			notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
 			notificationIntent.putExtra(TiGooshModule.INTENT_EXTRA, jsonData);
 
-			PendingIntent contentIntent = PendingIntent.getActivity(this, new Random().nextInt(), notificationIntent, PendingIntent.FLAG_ONE_SHOT);
+			PendingIntent contentIntent = PendingIntent.getActivity(context, new Random().nextInt(), notificationIntent, PendingIntent.FLAG_ONE_SHOT);
 
 			// Start building notification
 			NotificationCompat.Builder builder = null;
 
 			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-				builder = new NotificationCompat.Builder(context, createOrUpdateDefaultNotificationChannel().getId());
+				builder = new NotificationCompat.Builder(context, createOrUpdateDefaultNotificationChannel(context).getId());
 			} else {
 				builder = new NotificationCompat.Builder(context);
 			}
@@ -413,14 +426,14 @@ public class IntentService extends GcmListenerService {
 				if (idJson.isJsonPrimitive() && idJson.getAsJsonPrimitive().isNumber()) {
 					id = -1 * Math.abs(idJson.getAsJsonPrimitive().getAsInt());
 				}
-			} 
+			}
 
 			if (id == 0) {
 				id = atomic.getAndIncrement();
 			}
 
 			// Send
-			NotificationManager notificationManager = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
+			NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 			notificationManager.notify(tag, id, builder.build());
 		} else {
 			Log.w(LCAT, "Show Notification: FALSE");

--- a/android/src/ti/goosh/PushHandlerActivity.java
+++ b/android/src/ti/goosh/PushHandlerActivity.java
@@ -8,7 +8,6 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.util.Log;
 
-import org.appcelerator.titanium.TiApplication;
 import org.appcelerator.kroll.KrollRuntime;
 
 public class PushHandlerActivity extends Activity {
@@ -49,5 +48,5 @@ public class PushHandlerActivity extends Activity {
 		Log.d(LCAT, "resumed");
 		super.onResume();
 	}
-	
+
 }

--- a/android/timodule.xml
+++ b/android/timodule.xml
@@ -48,20 +48,25 @@
 				<!-- [END gcm_listener] -->
 
 				<!-- [START instanceId_listener] -->
-		        <service
-		            android:name="ti.goosh.InstanceIDListener"
-		            android:exported="false">
-		            <intent-filter>
-		                <action android:name="com.google.android.gms.iid.InstanceID"/>
-		            </intent-filter>
-		        </service>
-		        <!-- [END instanceId_listener] -->
+				<service
+					android:name="ti.goosh.InstanceIDListener"
+					android:exported="false">
+					<intent-filter>
+						<action android:name="com.google.android.gms.iid.InstanceID"/>
+					</intent-filter>
+				</service>
+				<!-- [END instanceId_listener] -->
+
+				<service
+					android:exported="false"
+					android:name="ti.goosh.GcmJobService"
+					android:permission="android.permission.BIND_JOB_SERVICE"/>
 
 				<service
 					android:name="ti.goosh.RegistrationIntentService"
 					android:exported="false">
 				</service>
-	
+
 				<activity
 					android:name="ti.goosh.PushHandlerActivity"
 					android:exported="true">

--- a/example-app/tiapp.xml
+++ b/example-app/tiapp.xml
@@ -44,7 +44,7 @@
 	</ios>
 	<android xmlns:android="http://schemas.android.com/apk/res/android">
 		<manifest android:versionCode="1" android:versionName="1.0">
-			<uses-sdk android:targetSdkVersion="25" android:minSdkVersion="16"/>
+			<uses-sdk android:targetSdkVersion="26" android:minSdkVersion="16"/>
 			<supports-screens android:xlargeScreens="false" android:largeScreens="true" android:normalScreens="true" android:smallScreens="true"/>
 			<application android:hardwareAccelerated="true">
 				<meta-data android:name="com.google.android.gms.version" android:value="@integer/google_play_services_version"/>
@@ -69,5 +69,5 @@
 		<target device="iphone">false</target>
 		<target device="mobileweb">false</target>
 	</deployment-targets>
-	<sdk-version>7.0.1.GA</sdk-version>
+	<sdk-version>7.4.0.GA</sdk-version>
 </ti:app>


### PR DESCRIPTION
Android 26 introduced radical changes to the way services are handled. The details are in the official page here: https://developer.android.com/about/versions/oreo/background#services
The result is that Ti.Goosh currently throws a `java.lang.IllegalStateException` whenever a notification is received while the app is closed or considered as "in background" by the system.
I solved this problem by starting our IntentService class through JobScheduler.

Solves #114 and #109